### PR TITLE
Adding usage for transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,17 +96,18 @@ array([-4.25627649e-01, -3.42006773e-01, -7.15175271e-02, -1.09820020e+00,
 
 
 ## 追記：transformersの利用
-2020.08.21 現在、pytorch-pretrained-bertはtransformersに置き換わっています。これに対応するには、若干の仕様変更が必要です。  
+2020.08.21 現在、`pytorch-pretrained-bert`は`transformers`に置き換わっています。これに対応するには、`bert_juman.py`に若干の仕様変更が必要です。  
 具体的には、隠れ層の出力を得るのに、モデルのforward時に引数を指定する必要があります。  
-まず、transformersはpytorch-pretrained-bertと同様に、pipでインストールすることができます。  
+まず、`transformers`は`pytorch-pretrained-bert`と同様に、pipでインストールすることができます。  
 
 ```sh
-$ pip install pytorch-pretrained-bert
+$ pip install transformers
 ```
 
 次に、下記のようにインポート元のライブラリ名を変更し、`get_sentence_embedding`関数内の、モデルのforward部分に引数を追加します。必要な変更は以上です。  
 変更後のコードは本レポジトリの`bert_juman_with_transformers.py`を参照してください。  
 
+bert_juman_with_transformers.py  
 ```python
 #from pytorch_pretrained_bert import BertTokenizer, BertModel   # pytorch_pretrained_bert was replaced with transformers
 from transformers import BertTokenizer, BertModel               # transformers

--- a/README.md
+++ b/README.md
@@ -93,3 +93,33 @@ Out[]:
 array([-4.25627649e-01, -3.42006773e-01, -7.15175271e-02, -1.09820020e+00,
         1.08186746e+00, -2.35576674e-01, -1.89862609e-01, -5.50959229e-01,
 ```
+
+
+## 追記：transformersの利用
+2020.08.21 現在、pytorch-pretrained-bertはtransformersに置き換わっています。これに対応するには、若干の仕様変更が必要です。  
+具体的には、隠れ層の出力を得るのに、モデルのforward時に引数を指定する必要があります。  
+まず、transformersはpytorch-pretrained-bertと同様に、pipでインストールすることができます。  
+
+```sh
+$ pip install pytorch-pretrained-bert
+```
+
+次に、下記のようにインポート元のライブラリ名を変更し、`get_sentence_embedding`関数内の、モデルのforward部分に引数を追加します。必要な変更は以上です。  
+変更後のコードは本レポジトリの`bert_juman_with_transformers.py`を参照してください。  
+
+```python
+#from pytorch_pretrained_bert import BertTokenizer, BertModel   # pytorch_pretrained_bert was replaced with transformers
+from transformers import BertTokenizer, BertModel               # transformers
+
+```
+
+```python
+    def get_sentence_embedding(self, text, pooling_layer=-2, pooling_strategy="REDUCE_MEAN"):
+
+        ...
+
+        self.model.eval()
+        with torch.no_grad():
+            # all_encoder_layers, _ = self.model(tokens_tensor) # for pytorch_pretrained_bert
+            all_encoder_layers = self.model(tokens_tensor, return_dict=True, output_hidden_states=True)["hidden_states"]  # for transformers
+```

--- a/bert_juman_with_transformers.py
+++ b/bert_juman_with_transformers.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import numpy as np
+import torch
+#from pytorch_pretrained_bert import BertTokenizer, BertModel   # pytorch_pretrained_bert was replaced with transformers
+from transformers import BertTokenizer, BertModel               # transformers
+
+from pyknp import Juman
+
+
+class JumanTokenizer():
+    def __init__(self):
+        self.juman = Juman()
+
+    def tokenize(self, text):
+        result = self.juman.analysis(text)
+        return [mrph.midasi for mrph in result.mrph_list()]
+
+
+class BertWithJumanModel():
+    def __init__(self, bert_path, vocab_file_name="vocab.txt", use_cuda=False):
+        self.juman_tokenizer = JumanTokenizer()
+        self.model = BertModel.from_pretrained(bert_path)
+        self.bert_tokenizer = BertTokenizer(Path(bert_path) / vocab_file_name,
+                                            do_lower_case=False, do_basic_tokenize=False)
+        self.use_cuda = use_cuda
+
+    def _preprocess_text(self, text):
+        return text.replace(" ", "")  # for Juman
+
+    def get_sentence_embedding(self, text, pooling_layer=-2, pooling_strategy="REDUCE_MEAN"):
+        preprocessed_text = self._preprocess_text(text)
+        tokens = self.juman_tokenizer.tokenize(preprocessed_text)
+        bert_tokens = self.bert_tokenizer.tokenize(" ".join(tokens))
+        ids = self.bert_tokenizer.convert_tokens_to_ids(["[CLS]"] + bert_tokens[:126] + ["[SEP]"]) # max_seq_len-2
+        tokens_tensor = torch.tensor(ids).reshape(1, -1)
+
+        if self.use_cuda:
+            tokens_tensor = tokens_tensor.to('cuda')
+            self.model.to('cuda')
+
+        self.model.eval()
+        with torch.no_grad():
+            # all_encoder_layers, _ = self.model(tokens_tensor) # for pytorch_pretrained_bert
+            all_encoder_layers = self.model(tokens_tensor, return_dict=True, output_hidden_states=True)["hidden_states"]  # for transformers
+
+        embedding = all_encoder_layers[pooling_layer].cpu().numpy()[0]
+        if pooling_strategy == "REDUCE_MEAN":
+            return np.mean(embedding, axis=0)
+        elif pooling_strategy == "REDUCE_MAX":
+            return np.max(embedding, axis=0)
+        elif pooling_strategy == "REDUCE_MEAN_MAX":
+            return np.r_[np.max(embedding, axis=0), np.mean(embedding, axis=0)]
+        elif pooling_strategy == "CLS_TOKEN":
+            return embedding[0]
+        else:
+            raise ValueError("specify valid pooling_strategy: {REDUCE_MEAN, REDUCE_MAX, REDUCE_MEAN_MAX, CLS_TOKEN}")


### PR DESCRIPTION
Hi, thank you for creating an excellent repository!  

I found that `pytorch-pretrained_bert` was replaced with `transformers`.  
Using `transformer` requires a modification on `bert_juman.py`. 
The modification is adding an argument `output_hidden_states=True` to get hidden states in the forward function of BERT.   

You can see the detail description about `output_hidden_states=True`  in the link as below,  
https://github.com/huggingface/transformers/blob/master/src/transformers/modeling_bert.py#L688  

I tried to describe the modification as this pull request. I hope it will be helpful for you.  
I attach my results as below,
```python
In [5]: from bert_juman_with_transformers import BertWithJumanModel

In [6]: bert = BertWithJumanModel("../../MODELS/bert/Japanese_L-12_H-768_A-12_E-30_BPE_transformers/")

In [7]: bert.get_sentence_embedding("吾輩は猫である。").shape
Out[7]: (768,)

In [8]: bert.get_sentence_embedding("吾輩は猫である。")
Out[8]:
array([-4.25627619e-01, -3.42006892e-01, -7.15176389e-02, -1.09820056e+00,
        1.08186698e+00, -2.35575914e-01, -1.89862773e-01, -5.50958455e-01,
        1.87978148e-01, -9.03697014e-01, -2.67813027e-01, -1.49959311e-01,
        5.91513515e-01, -3.52201462e-01,  1.84209332e-01,  4.01529483e-02,
        1.53244898e-01, -6.31160438e-01, -2.07539946e-01, -1.49968192e-01,
       -3.31581414e-01,  4.01663631e-01,  3.73950928e-01, -4.13331598e-01,
```
Note that the embedding is different because I used [an alternate model for transformers from Kurohashi-lab](http://nlp.ist.i.kyoto-u.ac.jp/index.php?BERT%E6%97%A5%E6%9C%AC%E8%AA%9EPretrained%E3%83%A2%E3%83%87%E3%83%AB).  (See "(更新: 19/11/15) ")

Thanks,  